### PR TITLE
fix: avoid external-helpers warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/node": "^9.3.0",
     "@types/resolve": "^0.0.6",
     "babel-core": "^6.26.0",
+    "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -44,6 +44,8 @@ async function generateBundleCode(
           require.resolve('babel-preset-react'),
           require.resolve('babel-preset-stage-2'),
         ],
+        plugins: ['external-helpers'],
+        externalHelpers: true,
       }),
       commonjs(),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,6 +602,12 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-external-helpers@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-istanbul@^4.1.4, babel-plugin-istanbul@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"


### PR DESCRIPTION
This avoids the following warning:

> The 'extends' Babel helper is used more than once in your code. It's strongly recommended that you use the "external-helpers" plugin or the "es2015-rollup" preset. See https://github.com/rollup/rollup-plugin-babel#configuring-babel for more information

Because of a [bug in rollup](https://github.com/rollup/rollup/pull/1905) this warning was swallowed and only `undefined` was printed.