### PR TITLE
fix: revert react-to-typescript-definitions to 0.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "fs-extra": "^5.0.0",
     "meow": "^4.0.0",
     "minimatch": "^3.0.4",
-    "react-to-typescript-definitions": "^0.28.1",
+    "react-to-typescript-definitions": "0.28.0",
     "rollup": "^0.56.4",
     "rollup-plugin-commonjs": "^9.0.0",
     "rollup-plugin-json": "^2.3.0",

--- a/src/__tests__/__snapshots__/generate.test.ts.snap
+++ b/src/__tests__/__snapshots__/generate.test.ts.snap
@@ -1,14 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generates typings for module export-from-js 1`] = `
-"declare module 'export-from-js' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'export-from-js' {
     export interface ComponentProps {
         foo: string;
     }
 
-    export type Component = React.SFC<ComponentProps>;
+    export function Component(props: ComponentProps): JSX.Element;
 
 }
 
@@ -16,14 +15,13 @@ exports[`generates typings for module export-from-js 1`] = `
 `;
 
 exports[`generates typings for module export-from-jsx 1`] = `
-"declare module 'export-from-jsx' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'export-from-jsx' {
     export interface ComponentProps {
         foo: string;
     }
 
-    export type Component = React.SFC<ComponentProps>;
+    export function Component(props: ComponentProps): JSX.Element;
 
 }
 
@@ -32,13 +30,13 @@ exports[`generates typings for module export-from-jsx 1`] = `
 
 exports[`generates typings for module stage-2-syntax 1`] = `
 "declare module 'stage-2-syntax' {
-    import * as React from 'react';
+    import {PureComponent} from 'react';
 
     export interface MyComponentProps {
         foo: string;
     }
 
-    export class MyComponent extends React.PureComponent<MyComponentProps, any> {
+    export class MyComponent extends PureComponent<MyComponentProps, any> {
         render(): JSX.Element;
 
     }
@@ -49,14 +47,13 @@ exports[`generates typings for module stage-2-syntax 1`] = `
 `;
 
 exports[`generates typings for module with-css-modules 1`] = `
-"declare module 'with-css-modules' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'with-css-modules' {
     export interface ComponentProps {
         foo: string;
     }
 
-    export type Component = React.SFC<ComponentProps>;
+    export function Component(props: ComponentProps): JSX.Element;
 
 }
 
@@ -64,20 +61,19 @@ exports[`generates typings for module with-css-modules 1`] = `
 `;
 
 exports[`generates typings for module with-dependency 1`] = `
-"declare module 'with-dependency' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'with-dependency' {
     export interface TestDependencyProps {
         foo: string;
     }
 
-    export type TestDependency = React.SFC<TestDependencyProps>;
+    export function TestDependency(props: TestDependencyProps): JSX.Element;
 
     export interface ComponentProps {
         foo: string;
     }
 
-    export default type Component = React.SFC<ComponentProps>;
+    export default function Component(props: ComponentProps): JSX.Element;
 
 }
 
@@ -85,14 +81,13 @@ exports[`generates typings for module with-dependency 1`] = `
 `;
 
 exports[`generates typings for module with-es5-dependency 1`] = `
-"declare module 'with-es5-dependency' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'with-es5-dependency' {
     export interface ComponentProps {
         foo: string;
     }
 
-    export default type Component = React.SFC<ComponentProps>;
+    export default function Component(props: ComponentProps): JSX.Element;
 
 }
 
@@ -100,14 +95,13 @@ exports[`generates typings for module with-es5-dependency 1`] = `
 `;
 
 exports[`generates typings for module with-json-dependency 1`] = `
-"declare module 'with-json-dependency' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'with-json-dependency' {
     export interface ComponentProps {
         foo: string;
     }
 
-    export default type Component = React.SFC<ComponentProps>;
+    export default function Component(props: ComponentProps): JSX.Element;
 
 }
 
@@ -115,14 +109,13 @@ exports[`generates typings for module with-json-dependency 1`] = `
 `;
 
 exports[`generates typings for module with-node-builtin-dependency 1`] = `
-"declare module 'with-node-builtin-dependency' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'with-node-builtin-dependency' {
     export interface ComponentProps {
         foo: string;
     }
 
-    export default type Component = React.SFC<ComponentProps>;
+    export default function Component(props: ComponentProps): JSX.Element;
 
 }
 

--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -18,14 +18,13 @@ exports[`cli() when an import can not be resolved exits and logs an error messag
 `;
 
 exports[`cli() with module export-from-js and a custom outDir writes the declaration file export-from-js.d.ts into the given directory 1`] = `
-"declare module 'export-from-js' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'export-from-js' {
     export interface ComponentProps {
         foo: string;
     }
 
-    export type Component = React.SFC<ComponentProps>;
+    export function Component(props: ComponentProps): JSX.Element;
 
 }
 
@@ -33,14 +32,13 @@ exports[`cli() with module export-from-js and a custom outDir writes the declara
 `;
 
 exports[`writeDeclarationFile() with a relative package dir writes a declaration file to the given package dir 1`] = `
-"declare module 'export-from-js' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'export-from-js' {
     export interface ComponentProps {
         foo: string;
     }
 
-    export type Component = React.SFC<ComponentProps>;
+    export function Component(props: ComponentProps): JSX.Element;
 
 }
 
@@ -48,14 +46,13 @@ exports[`writeDeclarationFile() with a relative package dir writes a declaration
 `;
 
 exports[`writeDeclarationFile() with an absolute package dir writes a declaration file to the given package dir 1`] = `
-"declare module 'export-from-js' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'export-from-js' {
     export interface ComponentProps {
         foo: string;
     }
 
-    export type Component = React.SFC<ComponentProps>;
+    export function Component(props: ComponentProps): JSX.Element;
 
 }
 
@@ -63,14 +60,13 @@ exports[`writeDeclarationFile() with an absolute package dir writes a declaratio
 `;
 
 exports[`writeDeclarationFile() with module export-from-js and a custom outDir writes the declaration file export-from-js.d.ts into the given directory 1`] = `
-"declare module 'export-from-js' {
-    import * as React from 'react';
-
+"/// <reference types=\\"react\\" />
+declare module 'export-from-js' {
     export interface ComponentProps {
         foo: string;
     }
 
-    export type Component = React.SFC<ComponentProps>;
+    export function Component(props: ComponentProps): JSX.Element;
 
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4510,9 +4510,9 @@ rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-to-typescript-definitions@^0.28.1:
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/react-to-typescript-definitions/-/react-to-typescript-definitions-0.28.1.tgz#1f51caa6aa61a8fbe9f3b47010ee5034a69ee959"
+react-to-typescript-definitions@0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/react-to-typescript-definitions/-/react-to-typescript-definitions-0.28.0.tgz#2e3fc26d576d6ce6692530c9889169f9c07cc451"
   dependencies:
     astq "^2.0.3"
     babel-generator "^6.26.0"


### PR DESCRIPTION
In 0.28.1 there is a bug with default exported SFCs.